### PR TITLE
Add expo CLI dependency and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Lista-de-pessoas
 App desenvolvido com React Native durante curso sobre React Native
+
+## Execução
+
+1. Instale as dependências: `npm install`.
+2. Inicie o projeto: `npx expo start`.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",
-    "babel-preset-expo": "~8.1.0"
+    "babel-preset-expo": "~8.1.0",
+    "expo-cli": "^6.3.12"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add expo-cli to dev dependencies
- document how to install and start the project

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start` *(fails: This command requires Expo CLI)*

------
https://chatgpt.com/codex/tasks/task_e_689d78b7c6548326acb497a4784b903f